### PR TITLE
Update main.tex - Including of Bibliography correctly

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -105,7 +105,7 @@
   % List of Citations
   % Standard bibliography
   \renewcommand{\bibname}{\bibliographyName}
-  \printbibliography
+  \printbibliography[heading=bibintoc] % Including of Bibliography | with option (heading=bibintoc) in table of contens and in the bookmarks of the pdf file
   % Bibliography filtered by print and web media
   % \renewcommand{\bibname}{\bibliographyName}
   % \printbibheading


### PR DESCRIPTION
Including of Bibliography | with option (heading=bibintoc) in table of contens and in the bookmarks of the pdf file

Bibliography was not displayed in the table of contents and also not in the bookmark of the pdf file. This modification solves this problem!