### PR TITLE
Update Template guide.md (using \acf)

### DIFF
--- a/Template guide.md
+++ b/Template guide.md
@@ -379,7 +379,7 @@ To add a new abbreviation, you must add your entry in `frame/acronyms.tex` like 
 2. \ac{TS}
 3. \acp{TS}
 4. \acl{TS}
-5. \aclp{TS}.
+5. \aclp{TS}
 6. \acf{TS} %prints always the full form of the acronym
 ```
 

--- a/Template guide.md
+++ b/Template guide.md
@@ -380,6 +380,7 @@ To add a new abbreviation, you must add your entry in `frame/acronyms.tex` like 
 3. \acp{TS}
 4. \acl{TS}
 5. \aclp{TS}.
+6. \acf{TS} %prints always the full form of the acronym
 ```
 
 *Results in:*
@@ -388,7 +389,10 @@ To add a new abbreviation, you must add your entry in `frame/acronyms.tex` like 
 2. TS
 3. TSs
 4. Temperature Sensor
-5. Temperature Sensors.
+5. Temperature Sensors
+6. Temperature Sensor (TS)
+
+[Source](https://ctan.math.illinois.edu/macros/latex/contrib/acro/acro-manual.pdf)
 
 ### Citation
 


### PR DESCRIPTION
Servus Berkay, hier fehlt noch das \acf mit dem man immer die Abkürzung in der kompletten Form dargestellt bekommt. Wichtig für den Text im Kurzreferat / Abstract da man hier ja dann 2 mal die Abkürzung voll ausschreiben muss.

BR
Lukas