### PR TITLE
Update createCollections.bash (Fix appendix autocollection: iterate over files individually)

### DIFF
--- a/.devcontainer/scripts/createCollections.bash
+++ b/.devcontainer/scripts/createCollections.bash
@@ -23,7 +23,7 @@ if [ -n "$appendix" ]; then
     printf "\\\\Appendix\n\n" >> "$appendixCollection"
 fi
 
-for APPEND in "$appendix"
+for APPEND in $appendix
 do
     echo "\\include{$APPEND}"
     mkdir -p auxiliary/$(dirname $APPEND)


### PR DESCRIPTION
This change is necessary so that not only the first, but also subsequent files in the appendix autocollection are read correctly.

The issue was on line 25: "$appendix" (with quotes) treats all files as a single string. It is now $appendix without quotes so the loop iterates over each file individually.

Without this adjustment, the content of `AUTOGEN_appendixCollection.tex` with two .tex files looks as follows:
```latex
% This file is autogenerated. Do not edit it manually. Changes will be lost.
\Appendix
\include{appendix/10Ansprechpartner.tex
appendix/20Example_Latex-Code.tex}
```